### PR TITLE
Put CXX standard explicitly into the cmake file, before buildfail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(Qt5Widgets REQUIRED)
 find_package(Qt5OpenGL REQUIRED)
 find_package(KF5TextEditor REQUIRED)
 
+set (CMAKE_CXX_STANDARD 11)
 set(QT5_LIBRARIES
 	Qt5::Widgets
 	Qt5::Core


### PR DESCRIPTION
Without explicit C++11 there was this build error for use of `nullptr` as C++11 keyword. On your machine it may have been a default gcc setting but not mine and maybe some other ;)